### PR TITLE
VALIDATION: JSON property conflicts fix

### DIFF
--- a/src/crewai/crews/crew_output.py
+++ b/src/crewai/crews/crew_output.py
@@ -24,7 +24,7 @@ class CrewOutput(BaseModel):
     token_usage: UsageMetrics = Field(description="Processed token summary", default={})
 
     @property
-    def json(self) -> Optional[str]:
+    def json_output(self) -> Optional[str]:
         if self.tasks_output[-1].output_format != OutputFormat.JSON:
             raise ValueError(
                 "No JSON output found in the final task. Please make sure to set the output_json property in the final task in your crew."

--- a/src/crewai/crews/crew_output.py
+++ b/src/crewai/crews/crew_output.py
@@ -26,12 +26,15 @@ class CrewOutput(BaseModel, JsonPropertyMixin):
 
     @property
     def json_output(self) -> Optional[str]:
-        if self.tasks_output[-1].output_format != OutputFormat.JSON:
+        if self.json_dict is not None:
+            return json.dumps(self.json_dict)
+        
+        if self.tasks_output and self.tasks_output[-1].output_format != OutputFormat.JSON:
             raise ValueError(
                 "No JSON output found in the final task. Please make sure to set the output_json property in the final task in your crew."
             )
 
-        return json.dumps(self.json_dict)
+        return None
 
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/crewai/crews/crew_output.py
+++ b/src/crewai/crews/crew_output.py
@@ -32,6 +32,11 @@ class CrewOutput(BaseModel):
 
         return json.dumps(self.json_dict)
 
+    @property
+    def json(self) -> Optional[str]:
+        """Backward compatibility property for existing tests."""
+        return self.json_output
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert json_output and pydantic_output to a dictionary."""
         output_dict = {}

--- a/src/crewai/crews/crew_output.py
+++ b/src/crewai/crews/crew_output.py
@@ -6,9 +6,10 @@ from pydantic import BaseModel, Field
 from crewai.tasks.output_format import OutputFormat
 from crewai.tasks.task_output import TaskOutput
 from crewai.types.usage_metrics import UsageMetrics
+from crewai.utilities.json_compatibility import JsonBackwardCompatibilityMixin
 
 
-class CrewOutput(BaseModel):
+class CrewOutput(BaseModel, JsonBackwardCompatibilityMixin):
     """Class that represents the result of a crew."""
 
     raw: str = Field(description="Raw output of crew", default="")
@@ -32,10 +33,6 @@ class CrewOutput(BaseModel):
 
         return json.dumps(self.json_dict)
 
-    @property
-    def json(self) -> Optional[str]:
-        """Backward compatibility property for existing tests."""
-        return self.json_output
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert json_output and pydantic_output to a dictionary."""

--- a/src/crewai/crews/crew_output.py
+++ b/src/crewai/crews/crew_output.py
@@ -6,10 +6,10 @@ from pydantic import BaseModel, Field
 from crewai.tasks.output_format import OutputFormat
 from crewai.tasks.task_output import TaskOutput
 from crewai.types.usage_metrics import UsageMetrics
-from crewai.utilities.json_compatibility import JsonBackwardCompatibilityMixin
+from crewai.utilities.json_compatibility import JsonPropertyMixin
 
 
-class CrewOutput(BaseModel, JsonBackwardCompatibilityMixin):
+class CrewOutput(BaseModel, JsonPropertyMixin):
     """Class that represents the result of a crew."""
 
     raw: str = Field(description="Raw output of crew", default="")

--- a/src/crewai/crews/crew_output.py
+++ b/src/crewai/crews/crew_output.py
@@ -9,7 +9,7 @@ from crewai.types.usage_metrics import UsageMetrics
 from crewai.utilities.json_compatibility import JsonPropertyMixin
 
 
-class CrewOutput(BaseModel, JsonPropertyMixin):
+class CrewOutput(JsonPropertyMixin, BaseModel):
     """Class that represents the result of a crew."""
 
     raw: str = Field(description="Raw output of crew", default="")

--- a/src/crewai/flow/flow.py
+++ b/src/crewai/flow/flow.py
@@ -196,9 +196,9 @@ class Flow(Generic[T], metaclass=FlowMeta):
         if self.initial_state is None:
             return {}  # type: ignore
         elif isinstance(self.initial_state, type):
-            return self.initial_state()
+            return cast(T, self.initial_state())
         else:
-            return self.initial_state
+            return cast(T, self.initial_state)
 
     @property
     def state(self) -> T:

--- a/src/crewai/tasks/task_output.py
+++ b/src/crewai/tasks/task_output.py
@@ -35,7 +35,7 @@ class TaskOutput(BaseModel):
         return self
 
     @property
-    def json(self) -> Optional[str]:
+    def json_output(self) -> Optional[str]:
         if self.output_format != OutputFormat.JSON:
             raise ValueError(
                 """

--- a/src/crewai/tasks/task_output.py
+++ b/src/crewai/tasks/task_output.py
@@ -4,10 +4,10 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field, model_validator
 
 from crewai.tasks.output_format import OutputFormat
-from crewai.utilities.json_compatibility import JsonBackwardCompatibilityMixin
+from crewai.utilities.json_compatibility import JsonPropertyMixin
 
 
-class TaskOutput(BaseModel, JsonBackwardCompatibilityMixin):
+class TaskOutput(BaseModel, JsonPropertyMixin):
     """Class that represents the result of a task."""
 
     description: str = Field(description="Description of the task")

--- a/src/crewai/tasks/task_output.py
+++ b/src/crewai/tasks/task_output.py
@@ -4,9 +4,10 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field, model_validator
 
 from crewai.tasks.output_format import OutputFormat
+from crewai.utilities.json_compatibility import JsonBackwardCompatibilityMixin
 
 
-class TaskOutput(BaseModel):
+class TaskOutput(BaseModel, JsonBackwardCompatibilityMixin):
     """Class that represents the result of a task."""
 
     description: str = Field(description="Description of the task")
@@ -47,10 +48,6 @@ class TaskOutput(BaseModel):
 
         return json.dumps(self.json_dict)
 
-    @property
-    def json(self) -> Optional[str]:
-        """Backward compatibility property for existing tests."""
-        return self.json_output
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert json_output and pydantic_output to a dictionary."""

--- a/src/crewai/tasks/task_output.py
+++ b/src/crewai/tasks/task_output.py
@@ -47,6 +47,11 @@ class TaskOutput(BaseModel):
 
         return json.dumps(self.json_dict)
 
+    @property
+    def json(self) -> Optional[str]:
+        """Backward compatibility property for existing tests."""
+        return self.json_output
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert json_output and pydantic_output to a dictionary."""
         output_dict = {}

--- a/src/crewai/tasks/task_output.py
+++ b/src/crewai/tasks/task_output.py
@@ -7,7 +7,7 @@ from crewai.tasks.output_format import OutputFormat
 from crewai.utilities.json_compatibility import JsonPropertyMixin
 
 
-class TaskOutput(BaseModel, JsonPropertyMixin):
+class TaskOutput(JsonPropertyMixin, BaseModel):
     """Class that represents the result of a task."""
 
     description: str = Field(description="Description of the task")

--- a/src/crewai/utilities/json_compatibility.py
+++ b/src/crewai/utilities/json_compatibility.py
@@ -1,0 +1,31 @@
+"""
+JSON backward compatibility mixin for avoiding Pydantic BaseModel.json() conflicts.
+
+Provides a consistent approach to maintaining backward compatibility when renaming
+json properties to avoid conflicts with Pydantic's built-in json() method.
+"""
+
+from typing import Optional
+
+
+class JsonBackwardCompatibilityMixin:
+    """
+    Mixin that provides backward compatibility for json property access.
+    
+    Classes that inherit from this mixin should implement a json_output property,
+    and this mixin will automatically provide a json property that delegates to it.
+    """
+    
+    @property
+    def json(self) -> Optional[str]:
+        """
+        Backward compatibility property for existing code expecting .json access.
+        
+        Delegates to json_output to maintain compatibility while avoiding
+        conflicts with Pydantic BaseModel.json() method.
+        """
+        if hasattr(self, 'json_output'):
+            return self.json_output
+        raise AttributeError(
+            f"{self.__class__.__name__} does not implement json_output property"
+        )

--- a/src/crewai/utilities/json_compatibility.py
+++ b/src/crewai/utilities/json_compatibility.py
@@ -8,7 +8,7 @@ json properties to avoid conflicts with Pydantic's built-in json() method.
 from typing import Optional
 
 
-class JsonBackwardCompatibilityMixin:
+class JsonPropertyMixin:
     """
     Mixin that provides backward compatibility for json property access.
     


### PR DESCRIPTION
Validation PR for CI/CodeRabbit testing before upstream submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the public JSON accessor from ".json" to ".json_output" across outputs; behavior remains the same (returns JSON string or raises if output isn't JSON).
* **Chore**
  * Restored a backward-compatible ".json" accessor that delegates to ".json_output" to ease transition—please update references to ".json_output" when convenient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->