### PR TITLE
fix: Remove unused imports from agent adapters and builders

### DIFF
--- a/src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
+++ b/src/crewai/agents/agent_adapters/langgraph/langgraph_adapter.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field, PrivateAttr
 
@@ -22,7 +22,6 @@ from crewai.utilities.events.agent_events import (
 )
 
 try:
-    from langchain_core.messages import ToolMessage
     from langgraph.checkpoint.memory import MemorySaver
     from langgraph.prebuilt import create_react_agent
 

--- a/src/crewai/agents/agent_builder/base_agent.py
+++ b/src/crewai/agents/agent_builder/base_agent.py
@@ -25,7 +25,6 @@ from crewai.security.security_config import SecurityConfig
 from crewai.tools.base_tool import BaseTool, Tool
 from crewai.utilities import I18N, Logger, RPMController
 from crewai.utilities.config import process_config
-from crewai.utilities.converter import Converter
 from crewai.utilities.string_utils import interpolate_only
 
 T = TypeVar("T", bound="BaseAgent")


### PR DESCRIPTION
## Summary  
- Remove unused AsyncIterable and ToolMessage imports from langgraph_adapter.py
- Remove unused Converter import from base_agent.py
- Improves code quality and reduces linting warnings

## Validation Status
- [x] Python syntax compilation passes
- [x] Ruff F401 validation passes  
- [ ] **CI Tests on Fork** - Waiting for CI to validate
- [ ] **Ready for Upstream** - After CI passes

This PR runs CI on the fork first before creating upstream PR.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up unused imports and reduced dependencies to streamline the codebase. No changes to behavior or public interfaces.

* **Chores**
  * Performed dependency hygiene to minimize potential conflicts and simplify maintenance. No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->